### PR TITLE
Fix 271: Use any() instead of firstWhere() to prevent unhandled StateError crash.

### DIFF
--- a/modules/ui/game/lib/src/npc/kid.dart
+++ b/modules/ui/game/lib/src/npc/kid.dart
@@ -13,31 +13,28 @@ import '../util/player_sprite_sheet.dart';
 import '../util/sounds.dart';
 
 class Kid extends GameDecoration {
-  Kid(
-    Vector2 position,
-  ) : super.withAnimation(
-          animation: NpcSpriteSheet.kidIdleLeft(),
-          position: position,
-          size: Vector2(valueByTileSize(8), valueByTileSize(11)),
-        );
+  Kid(Vector2 position)
+    : super.withAnimation(
+        animation: NpcSpriteSheet.kidIdleLeft(),
+        position: position,
+        size: Vector2(valueByTileSize(8), valueByTileSize(11)),
+      );
 
   bool conversationWithHero = false;
 
   @override
   void update(double dt) {
     super.update(dt);
-    if (!conversationWithHero && checkInterval('checkBossDead', 1000, dt)) {
-      try {
-        gameRef.enemies().firstWhere((e) => e is Boss);
-      } on Exception catch (_) {
-        conversationWithHero = true;
-        gameRef.camera.moveToTargetAnimated(
-          target: this,
-          onComplete: () {
-            _startConversation();
-          },
-        );
-      }
+    if (!conversationWithHero &&
+        checkInterval('checkBossDead', 1000, dt) &&
+        !gameRef.enemies().any((e) => e is Boss)) {
+      conversationWithHero = true;
+      gameRef.camera.moveToTargetAnimated(
+        target: this,
+        onComplete: () {
+          _startConversation();
+        },
+      );
     }
   }
 
@@ -72,9 +69,7 @@ class Kid extends GameDecoration {
       onChangeTalk: (index) {
         Sounds.interaction();
       },
-      logicalKeyboardKeysToNext: [
-        LogicalKeyboardKey.space,
-      ],
+      logicalKeyboardKeysToNext: [LogicalKeyboardKey.space],
     );
   }
 }


### PR DESCRIPTION
Fixes #271 

`firstWhere` throws a StateError when the matching element cannot be found. StateError implements Error, not Exception, so it was not caught by the existing try/catch.

Using `any` safely checks if the boss still exists.